### PR TITLE
Fix memory issue in DummyGraph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
             - g++-4.9
 
       env:
-        - MATRIX_EVAL="CXX_COMPILER=g++-4.9"
+        - MATRIX_EVAL="CXX_COMPILER=g++-4.9; sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90"
 
     - os: linux
       compiler: clang
@@ -53,8 +53,10 @@ before_install:
   - sudo sh cmake.sh --skip-license --exclude-subdir --prefix=/usr/local
   - export PATH=/usr/local/bin:$PATH
   - cmake --version
-
-
+  - g++ --version
+  - clang++ --version
+  - gcov --version
+  
 install:
   - cd $PARENTDIR/build
   - cmake $PARENTDIR -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCPM_SOURCE_CACHE=$HOME/cpm

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,11 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - lcov
+            - doxygen
             - g++-7
 
       env:
-        - MATRIX_EVAL="CXX_COMPILER=g++-7; sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 90"
+        - MATRIX_EVAL="CXX_COMPILER=g++-7; BUILD_TYPE=Coverage; GEN_DOC=TRUE; sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-7 90"
 
     - os: linux
       compiler: gcc
@@ -27,31 +28,38 @@ matrix:
           sources:
             - ubuntu-toolchain-r-test
           packages:
-            - lcov
             - g++-4.9
 
       env:
-        - MATRIX_EVAL="CXX_COMPILER=g++-4.9; sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90"
+        - MATRIX_EVAL="CXX_COMPILER=g++-4.9; BUILD_TYPE=Release;"
 
     - os: linux
       compiler: clang
-      addons:
-        apt:
-          packages:
-            - lcov
 
       env:
-        - MATRIX_EVAL="CXX_COMPILER=clang++"
+        - MATRIX_EVAL="CXX_COMPILER=clang++; BUILD_TYPE=Release;"
     
+cache:
+  directories:
+    - $HOME/.local
 
 before_install:
   - eval "${MATRIX_EVAL}"
   - PARENTDIR=$(pwd)
   - mkdir $PARENTDIR/build $HOME/cpm
   # Install a supported cmake version (>= 3.14)
-  - wget -O cmake.sh https://cmake.org/files/v3.14/cmake-3.14.0-Linux-x86_64.sh
-  - sudo sh cmake.sh --skip-license --exclude-subdir --prefix=/usr/local
-  - export PATH=/usr/local/bin:$PATH
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
+      mkdir -p $HOME/.local
+      CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.16.4/cmake-3.16.4-Linux-x86_64.tar.gz"
+      if [ ! -e $HOME/.local/bin/cmake ]; then
+          echo "CMake not found in the cache, get and extract it..."
+          travis_retry curl -L ${CMAKE_URL} \
+              | tar -xz -C $HOME/.local --strip-components=1
+      else
+          echo "Using cached CMake"
+      fi
+    fi
   - cmake --version
   - g++ --version
   - clang++ --version
@@ -59,15 +67,36 @@ before_install:
   
 install:
   - cd $PARENTDIR/build
-  - cmake $PARENTDIR -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCPM_SOURCE_CACHE=$HOME/cpm
-  - make
+  - cmake $PARENTDIR -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCPM_SOURCE_CACHE=$HOME/cpm
+  - make -j4
 
 script:
-  - make coverage
+  - |
+    if [[ "$GEN_DOC" == "TRUE" ]]; then
+      cmake --build . --target doc
+    fi
+  - |
+    if [[ "$BUILD_TYPE" == "Coverage" ]]; then
+      make coverage
+    else
+      make test
+    fi
 
 after_success:
   - cd $PARENTDIR/build
-  - lcov --list coverage_out.info.cleaned  # Show test report in travis log.
-  # Install coverals gem for uploading coverage to coveralls.
-  - gem install coveralls-lcov
-  - bash <(curl -s https://codecov.io/bash) -f coverage_out.info.cleaned || echo "Codecov did not collect coverage reports"
+  - |
+    if [[ "$BUILD_TYPE" == "Coverage" ]]; then
+      lcov --list coverage_out.info.cleaned  # Show test report in travis log.
+      bash <(curl -s https://codecov.io/bash) -f coverage_out.info.cleaned || echo "Codecov did not collect coverage reports"
+      #bash <(curl -s https://codecov.io/bash) -X gcov || echo "Codecov did not collect coverage reports"
+    fi
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN #You will need to add your (ENCRYPTED if set in the .travis.yml) GH token as environment variable of your project
+  keep-history: true
+  on:
+    branch: master
+    condition: $GEN_DOC = TRUE
+  local-dir: build/html
+  

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -7,7 +7,6 @@
 #endif
 
 #include <iostream>
-#include <stdlib.h>
 
 #include "example.h"
 #include "exampleConfig.h"
@@ -27,7 +26,6 @@ int main()
             << "."
             << PROJECT_VERSION_TWEAK
             << std::endl;
-  std::system("cat ../LICENSE");
 
   // Bring in the dummy class from the example source,
   // just to show that it is accessible from main.cpp.

--- a/cmake/ConfigSafeGuards.cmake
+++ b/cmake/ConfigSafeGuards.cmake
@@ -5,8 +5,8 @@ endif()
 
 # guard against bad build-type strings
 if (NOT CMAKE_BUILD_TYPE)
-    message(STATUS "No build type selected, default to Debug")
-    set(CMAKE_BUILD_TYPE "Debug")
+    message(STATUS "No build type selected, default to Release")
+    set(CMAKE_BUILD_TYPE "Release")
 endif()
 
 string(TOLOWER "${CMAKE_BUILD_TYPE}" cmake_build_type_tolower)

--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -66,7 +66,7 @@ function(target_set_warnings)
         #list(APPEND WarningFlags "/wd4365") #signed/unsigned mismatch
         #list(APPEND WarningFlags "/wd4668") # is not defined as a preprocessor macro, replacing with '0' for
       elseif(WGCC OR WCLANG)
-        list(APPEND WarningFlags -Wno-switch-enum)
+        list(APPEND WarningFlags "-Wno-switch-enum")
         if(WCLANG)
           list(APPEND WarningFlags -Wno-unknown-warning-option -Wno-padded -Wno-undef -Wno-reserved-id-macro -fcomment-block-commands=test,retval)
           if(NOT CMAKE_CXX_STANDARD EQUAL 98)

--- a/include/graph_abstractions/cfg_interface.hh
+++ b/include/graph_abstractions/cfg_interface.hh
@@ -110,13 +110,13 @@ public:
       if (deleted_nodes.find(block.get()) != deleted_nodes.end()) continue;
       if (reachable.find(block.get()) == reachable.end()) continue;
 
-      auto successor_count = [](const BlockInterface<GraphType> *block) -> unsigned {
-        return block->successors().size();
+      auto successor_count = [](const BlockInterface<GraphType> *block_ptr) -> unsigned {
+        return block_ptr->successors().size();
       };
 
-      auto predecessor_count = [&reachable](const BlockInterface<GraphType> *block) -> unsigned {
+      auto predecessor_count = [&reachable](const BlockInterface<GraphType> *block_ptr) -> unsigned {
         unsigned result{ 0 };
-        for (auto *pred : block->predecessors()) {
+        for (auto *pred : block_ptr->predecessors()) {
           if (reachable.find(pred) != reachable.end()) {
             result++;
           }

--- a/tests/dummy.cpp
+++ b/tests/dummy.cpp
@@ -6,11 +6,11 @@
 // Tests that don't naturally fit in the headers/.cpp files directly
 // can be placed in a tests/*.cpp file. Integration tests are a good example.
 
-DummyStatement::DummyStatement(unsigned id, std::string statement) : id(id),
-                                                                     statement(statement)
+DummyStatement::DummyStatement(unsigned id1, std::string statement1) : id(id1),
+                                                                       statement(statement1)
 {}
 
-DummyBlock::DummyBlock(unsigned id) : id(id)
+DummyBlock::DummyBlock(unsigned id1) : id(id1)
 {
   statements.emplace_back(id, std::to_string(id));
 }
@@ -28,7 +28,8 @@ DummyGraph::DummyGraph()
    *            2 --------> 4
    *                  3 --> 4
    */
-  for (int idx = 0; idx < 5; idx++)
+
+  for (size_t idx = 0; idx < 5; idx++)
     blocks.emplace_back(idx);
 
   for (auto &b : blocks) {

--- a/tests/dummy.cpp
+++ b/tests/dummy.cpp
@@ -1,6 +1,8 @@
 #include "dummy.hh"
 #include "doctest.h"
 
+#include <iostream>
+
 // Tests that don't naturally fit in the headers/.cpp files directly
 // can be placed in a tests/*.cpp file. Integration tests are a good example.
 
@@ -26,20 +28,29 @@ DummyGraph::DummyGraph()
    *            2 --------> 4
    *                  3 --> 4
    */
-  for (int idx = 0; idx < 5; idx++) {
+  for (int idx = 0; idx < 5; idx++)
     blocks.emplace_back(idx);
-    if (idx > 0)
-      blocks[idx - 1].push_successor(&blocks[idx]);
+
+  for (auto &b : blocks) {
+    if (b.id < 4)
+      b.push_successor(&blocks[b.id + 1]);
   }
   blocks[1].push_successor(&blocks[1]);
   blocks[2].push_successor(&blocks[4]);
   root = &blocks[0];
 }
 
-
 TEST_CASE("dummy graph works")
 {
   DummyGraph dg;
+  for (const auto &b : dg.blocks) {
+    bool has_someone_larger = false, has_someone = false;
+    for (const auto &successor : b.successors) {
+      has_someone = true;
+      has_someone_larger |= successor->id > b.id;
+    }
+    CHECK((!has_someone || has_someone_larger));
+  }
   CHECK(dg.doSomething() == true);
   CHECK(dg.blocks.size() == 5);
 }

--- a/tests/dummy_spl.cpp
+++ b/tests/dummy_spl.cpp
@@ -7,8 +7,8 @@ using Statement = DummyStatement;
 using Block = DummyBlock;
 
 template<>
-distillery::StatementInterface<DummyGraphSpecialization>::StatementInterface(const Statement *stmt)
-  : stmt(stmt) {}
+distillery::StatementInterface<DummyGraphSpecialization>::StatementInterface(const Statement *stmt1)
+  : stmt(stmt1) {}
 
 template<>
 distillery::BlockInterface<DummyGraphSpecialization>::BlockInterface(const Block *block)

--- a/tests/dummy_spl.cpp
+++ b/tests/dummy_spl.cpp
@@ -27,6 +27,7 @@ distillery::CfgInterface<DummyGraphSpecialization>::CfgInterface(DummyGraph &gra
     blocks.back()->set_block_id(block.id);
     corresponding_interface[block.id] = blocks.back().get();
   }
+
   for (const auto &block : graph.blocks) {
     for (const auto &successor : block.successors) {
       corresponding_interface[block.id]->add_successor(corresponding_interface[successor->id]);
@@ -43,7 +44,7 @@ TEST_CASE("dummy graph traversable using interface")
   DummyGraph dg;
   distillery::CfgInterface<DummyGraphSpecialization> dummy(dg);
 
-  for (const auto &block : dummy)
+  for (const auto &block : dummy) {
     switch (block->block_id()) {
     case 0:
       CHECK(block->to_string() == "{} -> [0] -> {1,}");
@@ -63,4 +64,5 @@ TEST_CASE("dummy graph traversable using interface")
     default:
       break;
     }
+  }
 }

--- a/tests/dummy_spl.cpp
+++ b/tests/dummy_spl.cpp
@@ -3,21 +3,23 @@
 #include <iostream>
 #include <unordered_map>
 
+namespace distillery {
+
 using Statement = DummyStatement;
 using Block = DummyBlock;
 
 template<>
-distillery::StatementInterface<DummyGraphSpecialization>::StatementInterface(const Statement *stmt1)
+StatementInterface<DummyGraphSpecialization>::StatementInterface(const Statement *stmt1)
   : stmt(stmt1) {}
 
 template<>
-distillery::BlockInterface<DummyGraphSpecialization>::BlockInterface(const Block *block)
+BlockInterface<DummyGraphSpecialization>::BlockInterface(const Block *block)
 {
   statements.emplace_back(new StatementInterface<DummyGraphSpecialization>(&block->statements.front()));
 }
 
 template<>
-distillery::CfgInterface<DummyGraphSpecialization>::CfgInterface(DummyGraph &graph)
+CfgInterface<DummyGraphSpecialization>::CfgInterface(DummyGraph &graph)
 {
   this->fun_name = "dummy";
   std::unordered_map<unsigned, BlockInterface<DummyGraphSpecialization> *> corresponding_interface;
@@ -27,7 +29,6 @@ distillery::CfgInterface<DummyGraphSpecialization>::CfgInterface(DummyGraph &gra
     blocks.back()->set_block_id(block.id);
     corresponding_interface[block.id] = blocks.back().get();
   }
-
   for (const auto &block : graph.blocks) {
     for (const auto &successor : block.successors) {
       corresponding_interface[block.id]->add_successor(corresponding_interface[successor->id]);
@@ -44,7 +45,7 @@ TEST_CASE("dummy graph traversable using interface")
   DummyGraph dg;
   distillery::CfgInterface<DummyGraphSpecialization> dummy(dg);
 
-  for (const auto &block : dummy) {
+  for (const auto &block : dummy)
     switch (block->block_id()) {
     case 0:
       CHECK(block->to_string() == "{} -> [0] -> {1,}");
@@ -64,5 +65,5 @@ TEST_CASE("dummy graph traversable using interface")
     default:
       break;
     }
-  }
 }
+}// namespace distillery


### PR DESCRIPTION
The `DummyGraph` constructor builds the blocks vector from size 0 to 5. In some compilers, this may kick the resizing login which may invalidate some `block.push_successor` refs (that's what was happening).

Either the vector shouldn't resize (possible only for default-insertible elems -- not `DummyBlock`, Or the refs should be used when the size is fixed.